### PR TITLE
Add first command-line arguments: config ini, output file name, contact matrix file

### DIFF
--- a/seir/model.py
+++ b/seir/model.py
@@ -129,7 +129,7 @@ class SEIR:
         self.population = self._fix_size(population)
 
         # Sanity checking on the contacts_matrix argument
-        if contacts_matrix:
+        if contacts_matrix and contacts_matrix.any():
             assert contacts_matrix.shape[0] == len(self.compartments)
             assert contacts_matrix.shape[1] == len(self.compartments)
         else:

--- a/seir/model.py
+++ b/seir/model.py
@@ -490,7 +490,7 @@ class SEIR:
             axis=-1)
         H_new_cases_a_day = np.multiply(self.hospitalization_probability,
                                         np.divide(Ehl, self.incubation_period))
-        Hwindow = np.ones(self.hospitalization_duration)
+        Hwindow = np.ones(round(self.hospitalization_duration))
         H_active_cases = np.stack([
             np.convolve(H_new_cases_a_day[:, i], Hwindow, mode='same')
             for i in range(self.num_compartments)
@@ -502,7 +502,7 @@ class SEIR:
         E_icu_lag = np.split(SEIR_icu_lag, 4, axis=-1)[2]
         ICU_new_cases_a_day = np.multiply(
             self.icu_probability, np.divide(E_icu_lag, self.incubation_period))
-        ICUwindow = np.ones(self.icu_duration)
+        ICUwindow = np.ones(round(self.icu_duration))
         ICU_active_cases = np.stack([
             np.convolve(ICU_new_cases_a_day[:, i], Hwindow, mode='same')
             for i in range(self.num_compartments)

--- a/seir/scripts/cli.py
+++ b/seir/scripts/cli.py
@@ -1,4 +1,3 @@
-import datetime
 import argparse
 import sys
 
@@ -52,7 +51,7 @@ def main(contacts_matrix_file, output_file):
 
     # Visualize the results
     visualize_seir_computation(results,
-                               show_individual_compartments = True)
+                               show_individual_compartments=True)
 
 
 if __name__ == '__main__':

--- a/seir/scripts/cli.py
+++ b/seir/scripts/cli.py
@@ -1,30 +1,38 @@
 import datetime
+import argparse
+import sys
 
 import numpy as np
 
 from seir.model import SEIR
 from seir.visualization import visualize_seir_computation
 
-def main():
+
+def main(contacts_matrix_file, output_file):
     # TODO: Create config-file parsing
-    # TODO: Handle reading contacts matrix from a file if provided
     # TODO: Handle somehow the creation of a restrictions function
     # TODO: Handle somehow the creation of an imports function
-
     # Setup the model
-    model = SEIR(incubation_period=3,
-                 infectious_period=7,
-                 initial_R0=2.3,
-                 hospitalization_probability=[0.01, 0, 0, 0, 0.2],
-                 hospitalization_duration=21,
-                 hospitalization_lag_from_onset=6,
-                 icu_probability=0.001,
-                 icu_duration=7,
-                 icu_lag_from_onset=21,
-                 death_probability=0.1,
-                 death_lag_from_onset=27,
-                 compartments=['G1', 'G2', 'G3', 'G4', 'G5'],
-                 population=[2.5e6, 1e6, 3e5, 5e4, 4e5])
+    kwargs = dict(
+        incubation_period=3,
+        infectious_period=7,
+        initial_R0=2.3,
+        hospitalization_probability=[0.01, 0, 0, 0, 0.2],
+        hospitalization_duration=21,
+        hospitalization_lag_from_onset=6,
+        icu_probability=0.001,
+        icu_duration=7,
+        icu_lag_from_onset=21,
+        death_probability=0.1,
+        death_lag_from_onset=27,
+        compartments=['G1', 'G2', 'G3', 'G4', 'G5'],
+        population=[2.5e6, 1e6, 3e5, 5e4, 4e5],
+    )
+    if contacts_matrix_file:
+        with open(contacts_matrix_file) as contacts_matrix_file:
+            kwargs["contacts_matrix"] = np.fromfile(contacts_matrix_file, dtype=np.int32)
+
+    model = SEIR(**kwargs)
 
     # Setup initial state
     model.set_initial_state(population_susceptible=0.99,
@@ -40,7 +48,7 @@ def main():
     results = model.evaluate_solution(time)
 
     # Save data
-    results.to_csv('outfile.csv')
+    results.to_csv(output_file)
 
     # Visualize the results
     visualize_seir_computation(results,
@@ -48,4 +56,8 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description='Modeling epidemics using the SEIR model')
+    parser.add_argument('-c', dest="contacts_matrix_file", type=str, help='File path to contact matrix file')
+    parser.add_argument('-o', dest="output_file", default="outfile.csv", type=str, help='Output file name')
+    args = parser.parse_args(sys.argv[1:])
+    main(args.contacts_matrix_file, args.output_file)

--- a/seir/scripts/cli.py
+++ b/seir/scripts/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import configparser
 import sys
 
 import numpy as np
@@ -7,26 +8,28 @@ from seir.model import SEIR
 from seir.visualization import visualize_seir_computation
 
 
-def main(contacts_matrix_file, output_file):
-    # TODO: Create config-file parsing
+def parse_config_ini(config_file):
+    config = configparser.ConfigParser()
+    config.optionxform = str  # Avoids lower-casing of keys
+    config.read(config_file)
+    kwargs = {}
+    for key, value in config.items("model"):
+        if "," in value:
+            if key == "compartments":
+                kwargs[key] = value.split(",")
+            else:
+                kwargs[key] = [float(x) for x in value.split(",")]
+        else:
+            kwargs[key] = float(value)
+    return kwargs
+
+
+def main(config_file, contacts_matrix_file, output_file):
     # TODO: Handle somehow the creation of a restrictions function
     # TODO: Handle somehow the creation of an imports function
     # Setup the model
-    kwargs = dict(
-        incubation_period=3,
-        infectious_period=7,
-        initial_R0=2.3,
-        hospitalization_probability=[0.01, 0, 0, 0, 0.2],
-        hospitalization_duration=21,
-        hospitalization_lag_from_onset=6,
-        icu_probability=0.001,
-        icu_duration=7,
-        icu_lag_from_onset=21,
-        death_probability=0.1,
-        death_lag_from_onset=27,
-        compartments=['G1', 'G2', 'G3', 'G4', 'G5'],
-        population=[2.5e6, 1e6, 3e5, 5e4, 4e5],
-    )
+    kwargs = parse_config_ini(config_file)
+
     if contacts_matrix_file:
         with open(contacts_matrix_file) as contacts_matrix_file:
             kwargs["contacts_matrix"] = np.fromfile(contacts_matrix_file, dtype=np.int32)
@@ -56,7 +59,8 @@ def main(contacts_matrix_file, output_file):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Modeling epidemics using the SEIR model')
+    parser.add_argument('config_file', type=str, help='File path to config ini file')
     parser.add_argument('-c', dest="contacts_matrix_file", type=str, help='File path to contact matrix file')
     parser.add_argument('-o', dest="output_file", default="outfile.csv", type=str, help='Output file name')
     args = parser.parse_args(sys.argv[1:])
-    main(args.contacts_matrix_file, args.output_file)
+    main(args.config_file, args.contacts_matrix_file, args.output_file)

--- a/seir/scripts/sample.ini
+++ b/seir/scripts/sample.ini
@@ -1,0 +1,14 @@
+[model]
+incubation_period=3
+infectious_period=7
+initial_R0=2.3
+hospitalization_probability=0.01,0,0,0,0.2
+hospitalization_duration=21
+hospitalization_lag_from_onset=6
+icu_probability=0.001
+icu_duration=7
+icu_lag_from_onset=21
+death_probability=0.1
+death_lag_from_onset=27
+compartments=G1,G2,G3,G4,G5
+population=2.5e6,1e6,3e5,5e4,4e5


### PR DESCRIPTION
cli.py now accepts 3 arguments, one is mandatory (the ini file with the model parameters). The other 2 are optional. Let me know if it is not suitable to have all model parameters be interpreted as float. For hospitalization_duration and icu_duration it used to be int.

```
python cli.py  --help
usage: cli.py [-h] [-c CONTACTS_MATRIX_FILE] [-o OUTPUT_FILE] config_file

Modeling epidemics using the SEIR model

positional arguments:
  config_file           File path to config ini file

optional arguments:
  -h, --help            show this help message and exit
  -c CONTACTS_MATRIX_FILE
                        File path to contact matrix file
  -o OUTPUT_FILE        Output file name

```