### PR TITLE
Fix output_file_format comparison in cli.py

### DIFF
--- a/SEIR/cli.py
+++ b/SEIR/cli.py
@@ -52,7 +52,7 @@ def main(config_file, contacts_matrix_file, visualize_compartments, output_file_
     results = model.evaluate_solution(time)
 
     # Save data
-    if output_file == 'csv':
+    if output_file_format == 'csv':
         output_file = output_file or os.path.basename(f'{config_file}.csv')
         results.to_csv(output_file)
     elif output_file_format == 'json':


### PR DESCRIPTION
Fixes a bug in the comparison of the output file format, which results in no output file being generated when exporting to csv.

Please let me know if there is any information that needs to be added to this PR for it to be considered! 

Kind regards,
Sondre Sortland